### PR TITLE
fixed bug to leverage all spatialite features within sf + wrote test …

### DIFF
--- a/R/sql_lite_db.R
+++ b/R/sql_lite_db.R
@@ -80,7 +80,9 @@ write_table.sf <- function(df,
                              layer = tbl_name,
                              append = T,
                              delete_dsn  = length(existing_tables) == 0,   # T will delete the entire db ONLY if there are no tables -- can be the case since RSQLite::dbConnect creates an empty file which breaks st_write
-                             driver = 'SQLite')
+                             driver = 'SQLite',
+                             dataset_options=c("SPATIALITE=YES") #important! allows using st_area and st_distance from within spatialite
+                             )
 
     # DB and table exist and we do not want to overwrite
   }else{
@@ -294,7 +296,8 @@ append_new_records.sf <- function(df,
                  layer = tbl_name,
                  append = T,
                  delete_dsn  = F,
-                 driver = 'SQLite')
+                 driver = 'SQLite',
+                 dataset_options=c("SPATIALITE=YES") )
   }else{
     print(glue::glue('No new records added -- all {nrow(df)} already exist -- duplicates identified based on keys: {key_str}'))
   }


### PR DESCRIPTION

# Description

Fixed bug in `st_write` to ensure we can leverage all spatialite features. Related to issue [raised on sf](https://github.com/r-spatial/sf/issues/2050).

Fixed by adding `dataset_options=c("SPATIALITE=YES") ` both for appending and writing with `sf::st_write`

# Checklist:


* [ ] I have performed a self-review of my own code.
* [X] I have written unit tests to `tests` and run devtools::test()
* [X] I have commented my code
* [ ] I have updated the README + DESCRIPTION when appropriate
* [ ] I have updated the documentation and run devtools::document() + checked exported functions are in NAMESPACE
* [ ] I have run pkgdown::build_site_github_pages() + inspected the documentation site
* [ ] I have run R-CMD-CHECK locally
* [ ] I have run covr::package_coverage()
* [ ] I have run lintr::lint_package()

# Type of PR (may select more than one)

* [ ] New feature
* [X] Bug fix

