### PR TITLE
workflows trigger only at PR + protected master master -> should avoi…

### DIFF
--- a/.github/workflows/R-CMD-check_with_doc.yaml
+++ b/.github/workflows/R-CMD-check_with_doc.yaml
@@ -2,9 +2,6 @@ on:
   pull_request:
     branches:
       [main, master]
-  push:
-    branches:
-      [main, master]
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      [main, master]
   pull_request:
     branches:
       [master, main]


### PR DESCRIPTION

# Description

Tweak to try avoiding infinite PR loops when triggering workflows.

# Checklist:


* [ ] I have performed a self-review of my own code.
* [ ] I have written unit tests to `tests` and run devtools::test()
* [ ] I have commented my code
* [ ] I have updated the README + DESCRIPTION when appropriate
* [ ] I have updated the documentation and run devtools::document() + checked exported functions are in NAMESPACE
* [ ] I have run pkgdown::build_site_github_pages() + inspected the documentation site
* [ ] I have run R-CMD-CHECK locally
* [ ] I have run covr::package_coverage()
* [ ] I have run lintr::lint_package()

# Type of PR (may select more than one)

* [ ] New feature
* [ ] Bug fix

